### PR TITLE
Add publishers for camera information.

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
    //androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation 'com.google.ar:core:1.5.0'
+    implementation 'com.google.ar:core:1.18.0'
 
 }
 

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/MainActivity.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/MainActivity.java
@@ -18,6 +18,7 @@ import android.widget.Toast;
 /* ARCore Imports */
 import com.google.ar.core.ArCoreApk;
 import com.google.ar.core.Camera;
+import com.google.ar.core.Config;
 import com.google.ar.core.Frame;
 import com.google.ar.core.Pose;
 import com.google.ar.core.Session;
@@ -207,6 +208,11 @@ public class MainActivity extends RosActivity implements GLSurfaceView.Renderer 
                     case INSTALLED:
                         // Success, create the AR session.
                         mSession = new Session(this);
+                        if (mSession.isDepthModeSupported(Config.DepthMode.AUTOMATIC)) {
+                            Config config = mSession.getConfig();
+                            config.setDepthMode(Config.DepthMode.AUTOMATIC);
+                            mSession.configure(config);
+                        }
                         break;
                     case INSTALL_REQUESTED:
                         // Ensures next invocation of requestInstall() will either return

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
@@ -74,6 +74,7 @@ public class PublisherRosNode extends AbstractNodeMain {
         publisherSensors.add(PublisherSensorFactory.createImu(n, mContext));
         publisherSensors.add(PublisherSensorFactory.createGps(n ,mContext));
         publisherSensors.add(PublisherSensorFactory.createOdom(n, liveFrame));
+        publisherSensors.add(PublisherSensorFactory.createCompressedImageCamera(n, liveFrame));
 
         for(PublisherSensor s: publisherSensors) {
             s.startPublishing();

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
@@ -77,6 +77,7 @@ public class PublisherRosNode extends AbstractNodeMain {
         publisherSensors.add(PublisherSensorFactory.createCompressedImageCamera(n, liveFrame));
         publisherSensors.add(PublisherSensorFactory.createDepthImage(n, liveFrame));
         publisherSensors.add(PublisherSensorFactory.createCameraInfo(n, liveFrame));
+        publisherSensors.add(PublisherSensorFactory.createPointcloud(n, liveFrame));
 
         for(PublisherSensor s: publisherSensors) {
             s.startPublishing();

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
@@ -76,6 +76,7 @@ public class PublisherRosNode extends AbstractNodeMain {
         publisherSensors.add(PublisherSensorFactory.createOdom(n, liveFrame));
         publisherSensors.add(PublisherSensorFactory.createCompressedImageCamera(n, liveFrame));
         publisherSensors.add(PublisherSensorFactory.createDepthImage(n, liveFrame));
+        publisherSensors.add(PublisherSensorFactory.createCameraInfo(n, liveFrame));
 
         for(PublisherSensor s: publisherSensors) {
             s.startPublishing();

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherRosNode.java
@@ -75,6 +75,7 @@ public class PublisherRosNode extends AbstractNodeMain {
         publisherSensors.add(PublisherSensorFactory.createGps(n ,mContext));
         publisherSensors.add(PublisherSensorFactory.createOdom(n, liveFrame));
         publisherSensors.add(PublisherSensorFactory.createCompressedImageCamera(n, liveFrame));
+        publisherSensors.add(PublisherSensorFactory.createDepthImage(n, liveFrame));
 
         for(PublisherSensor s: publisherSensors) {
             s.startPublishing();

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
@@ -4,12 +4,15 @@ import android.content.Context;
 
 import com.google.ar.core.Frame;
 import com.jamie.android_ros.arcore_ros.common.LiveData;
+import com.jamie.android_ros.arcore_ros.ros.converters.CompressedImageMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.GpsMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.ImuMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.OdometryMessageConverter;
+import com.jamie.android_ros.arcore_ros.ros.publishers.CompressedImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.GpsPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.ImuPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.OdometryPublisher;
+import com.jamie.android_ros.arcore_ros.ros.sensors.CompressedImageCameraSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.GpsSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.ImuSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.OdometrySensor;
@@ -34,5 +37,13 @@ public class PublisherSensorFactory {
         return new PublisherSensor(
                 new OdometrySensor(liveFrame, null),
                 new OdometryPublisher(node, new OdometryMessageConverter(), "android/odom" ));
+    }
+
+    public static PublisherSensor createCompressedImageCamera(ConnectedNode node,
+                                                              LiveData<Frame> liveFrame) {
+        return new PublisherSensor(
+                new CompressedImageCameraSensor(liveFrame),
+                new CompressedImagePublisher(node, new CompressedImageMessageConverter(),
+                                             "android/camera/compressed_image"));
     }
 }

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
@@ -4,11 +4,13 @@ import android.content.Context;
 
 import com.google.ar.core.Frame;
 import com.jamie.android_ros.arcore_ros.common.LiveData;
+import com.jamie.android_ros.arcore_ros.ros.converters.CameraInfoMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.CompressedImageMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.DepthImageMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.GpsMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.ImuMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.OdometryMessageConverter;
+import com.jamie.android_ros.arcore_ros.ros.publishers.CameraInfoPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.CompressedImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.DepthImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.GpsPublisher;
@@ -55,5 +57,13 @@ public class PublisherSensorFactory {
                 new CameraSensor(liveFrame),
                 new DepthImagePublisher(node, new DepthImageMessageConverter(),
                         "android/camera/depth_image"));
+    }
+
+    public static PublisherSensor createCameraInfo(ConnectedNode node,
+                                                   LiveData<Frame> liveFrame) {
+        return new PublisherSensor(
+                new CameraSensor(liveFrame),
+                new CameraInfoPublisher(node, new CameraInfoMessageConverter(),
+                        "android/camera/camera_info"));
     }
 }

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
@@ -10,12 +10,14 @@ import com.jamie.android_ros.arcore_ros.ros.converters.DepthImageMessageConverte
 import com.jamie.android_ros.arcore_ros.ros.converters.GpsMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.ImuMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.OdometryMessageConverter;
+import com.jamie.android_ros.arcore_ros.ros.converters.PointcloudMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.publishers.CameraInfoPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.CompressedImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.DepthImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.GpsPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.ImuPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.OdometryPublisher;
+import com.jamie.android_ros.arcore_ros.ros.publishers.PointcloudPublisher;
 import com.jamie.android_ros.arcore_ros.ros.sensors.CameraSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.GpsSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.ImuSensor;
@@ -65,5 +67,13 @@ public class PublisherSensorFactory {
                 new CameraSensor(liveFrame),
                 new CameraInfoPublisher(node, new CameraInfoMessageConverter(),
                         "android/camera/camera_info"));
+    }
+
+    public static PublisherSensor createPointcloud(ConnectedNode node,
+                                                   LiveData<Frame> liveFrame) {
+        return new PublisherSensor(
+                new CameraSensor(liveFrame),
+                new PointcloudPublisher(node, new PointcloudMessageConverter(),
+                        "android/camera/pointcloud2"));
     }
 }

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/PublisherSensorFactory.java
@@ -5,14 +5,16 @@ import android.content.Context;
 import com.google.ar.core.Frame;
 import com.jamie.android_ros.arcore_ros.common.LiveData;
 import com.jamie.android_ros.arcore_ros.ros.converters.CompressedImageMessageConverter;
+import com.jamie.android_ros.arcore_ros.ros.converters.DepthImageMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.GpsMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.ImuMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.converters.OdometryMessageConverter;
 import com.jamie.android_ros.arcore_ros.ros.publishers.CompressedImagePublisher;
+import com.jamie.android_ros.arcore_ros.ros.publishers.DepthImagePublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.GpsPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.ImuPublisher;
 import com.jamie.android_ros.arcore_ros.ros.publishers.OdometryPublisher;
-import com.jamie.android_ros.arcore_ros.ros.sensors.CompressedImageCameraSensor;
+import com.jamie.android_ros.arcore_ros.ros.sensors.CameraSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.GpsSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.ImuSensor;
 import com.jamie.android_ros.arcore_ros.ros.sensors.OdometrySensor;
@@ -42,8 +44,16 @@ public class PublisherSensorFactory {
     public static PublisherSensor createCompressedImageCamera(ConnectedNode node,
                                                               LiveData<Frame> liveFrame) {
         return new PublisherSensor(
-                new CompressedImageCameraSensor(liveFrame),
+                new CameraSensor(liveFrame),
                 new CompressedImagePublisher(node, new CompressedImageMessageConverter(),
                                              "android/camera/compressed_image"));
+    }
+
+    public static PublisherSensor createDepthImage(ConnectedNode node,
+                                                              LiveData<Frame> liveFrame) {
+        return new PublisherSensor(
+                new CameraSensor(liveFrame),
+                new DepthImagePublisher(node, new DepthImageMessageConverter(),
+                        "android/camera/depth_image"));
     }
 }

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CameraInfoMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CameraInfoMessageConverter.java
@@ -10,6 +10,12 @@ import org.ros.message.Time;
 
 import sensor_msgs.CameraInfo;
 
+/**
+ * Populates {@code CameraInfo} ROS messages when a new frame arrives.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class CameraInfoMessageConverter implements DataToRosMessageConverter<CameraInfo, Frame> {
 
     private static final String TAG = CameraInfoMessageConverter.class.getSimpleName();

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CameraInfoMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CameraInfoMessageConverter.java
@@ -1,0 +1,56 @@
+package com.jamie.android_ros.arcore_ros.ros.converters;
+
+import android.util.Log;
+
+import com.google.ar.core.CameraIntrinsics;
+import com.google.ar.core.Frame;
+import com.google.ar.core.exceptions.NotYetAvailableException;
+
+import org.ros.message.Time;
+
+import sensor_msgs.CameraInfo;
+
+public class CameraInfoMessageConverter implements DataToRosMessageConverter<CameraInfo, Frame> {
+
+    private static final String TAG = CameraInfoMessageConverter.class.getSimpleName();
+    private boolean alreadyHaveCameraInfo = false;
+    private int width;
+    private int height;
+
+    @Override
+    public CameraInfo toRosMessage(Frame frame, CameraInfo baseMessage) {
+        if (!alreadyHaveCameraInfo) {
+            android.media.Image image;
+            try {
+                image = frame.acquireCameraImage();
+            } catch (NotYetAvailableException e) {
+                Log.w(TAG, e.getMessage());
+                return baseMessage;
+            }
+            width = image.getWidth();
+            height = image.getHeight();
+            image.close();
+            alreadyHaveCameraInfo = true;
+        }
+
+        baseMessage.getHeader().setFrameId("camera");
+        baseMessage.getHeader().setStamp(Time.fromMillis(frame.getTimestamp()));
+        baseMessage.setWidth(width);
+        baseMessage.setHeight(height);
+        CameraIntrinsics intrinsics = frame.getCamera().getImageIntrinsics();
+        double[] K = {intrinsics.getFocalLength()[0], 0, intrinsics.getPrincipalPoint()[0],
+                      0, intrinsics.getFocalLength()[1], intrinsics.getPrincipalPoint()[1],
+                      0, 0, 1};
+        double[] R = {1, 0, 0,
+                      0, 1, 0,
+                      0, 0, 1};
+        double[] P = {intrinsics.getFocalLength()[0], 0, intrinsics.getPrincipalPoint()[0], 0,
+                      0, intrinsics.getFocalLength()[1], intrinsics.getPrincipalPoint()[1], 0,
+                      0, 0, 1, 0};
+        baseMessage.setK(K);
+        baseMessage.setR(R);
+        baseMessage.setP(P);
+
+        return baseMessage;
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CompressedImageMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CompressedImageMessageConverter.java
@@ -1,0 +1,73 @@
+package com.jamie.android_ros.arcore_ros.ros.converters;
+
+import android.graphics.ImageFormat;
+import android.graphics.Rect;
+import android.graphics.YuvImage;
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.google.ar.core.exceptions.NotYetAvailableException;
+
+import org.jboss.netty.buffer.ChannelBufferOutputStream;
+import org.ros.internal.message.MessageBuffers;
+import org.ros.message.Time;
+
+import java.nio.ByteBuffer;
+
+import sensor_msgs.CompressedImage;
+
+public class CompressedImageMessageConverter
+        implements DataToRosMessageConverter<CompressedImage, Frame> {
+
+    private ChannelBufferOutputStream stream = new ChannelBufferOutputStream(
+            MessageBuffers.dynamicBuffer());
+    private static final String TAG = CompressedImageMessageConverter.class.getSimpleName();
+
+    @Override
+    public CompressedImage toRosMessage(Frame frame, CompressedImage baseMessage) {
+        android.media.Image image;
+        try {
+            image = frame.acquireCameraImage();
+        } catch (NotYetAvailableException e) {
+            Log.w(TAG, e.getMessage());
+            return baseMessage;
+        }
+        baseMessage.setFormat("jpeg");
+        baseMessage.getHeader().setFrameId("camera");
+        baseMessage.getHeader().setStamp(Time.fromMillis(frame.getTimestamp()));
+        SetImageToCompressedJPEGInBuffer(image);
+        baseMessage.setData(stream.buffer().copy());
+        // Clear the buffer and release the image.
+        stream.buffer().clear();
+        image.close();
+        return baseMessage;
+    }
+
+    private byte[] YUV_420_888toNV21(android.media.Image image) {
+        byte[] nv21;
+        ByteBuffer yBuffer = image.getPlanes()[0].getBuffer();
+        ByteBuffer uBuffer = image.getPlanes()[1].getBuffer();
+        ByteBuffer vBuffer = image.getPlanes()[2].getBuffer();
+
+        int ySize = yBuffer.remaining();
+        int uSize = uBuffer.remaining();
+        int vSize = vBuffer.remaining();
+
+        nv21 = new byte[ySize + uSize + vSize];
+
+        // U and V channels are swapped.
+        yBuffer.get(nv21, 0, ySize);
+        vBuffer.get(nv21, ySize, vSize);
+        uBuffer.get(nv21, ySize + vSize, uSize);
+
+        return nv21;
+    }
+
+    private void SetImageToCompressedJPEGInBuffer(android.media.Image image) {
+        Rect rect = new Rect(0, 0, image.getWidth(), image.getHeight());
+        byte bytes[] = YUV_420_888toNV21(image);
+        YuvImage yuvImage =
+                new YuvImage(bytes, ImageFormat.NV21, image.getWidth(), image.getHeight(), null);
+        yuvImage.compressToJpeg(rect, 20, stream);
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CompressedImageMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/CompressedImageMessageConverter.java
@@ -16,6 +16,12 @@ import java.nio.ByteBuffer;
 
 import sensor_msgs.CompressedImage;
 
+/**
+ * Converts {@code Frame} objects to {@code CompressedImage} ROS messages.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class CompressedImageMessageConverter
         implements DataToRosMessageConverter<CompressedImage, Frame> {
 

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/DepthImageMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/DepthImageMessageConverter.java
@@ -15,6 +15,13 @@ import java.nio.ByteBuffer;
 
 import sensor_msgs.Image;
 
+/**
+ * Converts {@code Frame} objects to {@code Image} ROS messages.
+ * The resulting image message has greyscale depth information.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class DepthImageMessageConverter
         implements DataToRosMessageConverter<Image, Frame> {
 

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/DepthImageMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/DepthImageMessageConverter.java
@@ -1,0 +1,70 @@
+package com.jamie.android_ros.arcore_ros.ros.converters;
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.google.ar.core.exceptions.NotYetAvailableException;
+
+import org.jboss.netty.buffer.ChannelBufferOutputStream;
+import org.jboss.netty.buffer.ChannelBuffers;
+import org.ros.internal.message.MessageBuffers;
+import org.ros.message.Time;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import sensor_msgs.Image;
+
+public class DepthImageMessageConverter
+        implements DataToRosMessageConverter<Image, Frame> {
+
+    private ChannelBufferOutputStream stream = new ChannelBufferOutputStream(
+            MessageBuffers.dynamicBuffer());
+    private static final String TAG = DepthImageMessageConverter.class.getSimpleName();
+
+    @Override
+    public Image toRosMessage(Frame frame, Image baseMessage) {
+        android.media.Image depthImage;
+        try {
+            depthImage = frame.acquireDepthImage();
+        } catch (NotYetAvailableException e) {
+            Log.w(TAG, e.getMessage());
+            return baseMessage;
+        } catch (IllegalStateException e){
+            Log.w(TAG, "Depth image is not supported on this device.");
+            return baseMessage;
+        }
+
+        baseMessage.setIsBigendian((byte) 1);
+        baseMessage.setWidth(depthImage.getWidth());
+        baseMessage.setHeight(depthImage.getHeight());
+        baseMessage.getHeader().setFrameId("camera");
+        baseMessage.getHeader().setStamp(Time.fromMillis(frame.getTimestamp()));
+        baseMessage.setEncoding("mono16");
+        // The step is the amount of bytes in one row of the image.
+        // Since the depth image is in int16 format, each pixel is represented with 2 bytes.
+        baseMessage.setStep(depthImage.getWidth() * 2);
+        SetDepthImageInBuffer(depthImage);
+        baseMessage.setData(stream.buffer().copy());
+        // Clear the buffer and release the image.
+        stream.buffer().clear();
+        depthImage.close();
+        return baseMessage;
+    }
+
+    private void SetDepthImageInBuffer(android.media.Image image) {
+        ByteBuffer byteBuffer =  image.getPlanes()[0].getBuffer();
+        stream = (ChannelBufferOutputStream) ChannelBuffers.copiedBuffer(byteBuffer);
+        ByteBuffer buffer =  image.getPlanes()[0].getBuffer();
+        int size = buffer.remaining();
+        byte[] byteArray = new byte[size];
+        buffer.get(byteArray, 0, size);
+        try {
+            stream.write(byteArray);
+        } catch (IOException e) {
+            Log.w(TAG, "Exception writing depth image: " + e.getMessage());
+            stream.buffer().clear();
+        }
+    }
+
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/PointcloudMessageConverter.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/converters/PointcloudMessageConverter.java
@@ -1,0 +1,55 @@
+package com.jamie.android_ros.arcore_ros.ros.converters;
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.google.ar.core.PointCloud;
+
+import org.jboss.netty.buffer.ChannelBuffer;
+
+import java.nio.ByteBuffer;
+import java.nio.FloatBuffer;
+
+import sensor_msgs.PointCloud2;
+
+/**
+ * Converts {@code Frame} objetcs into {@code Pointcloud2} ROS messages.
+ *
+ * @authors elector102, lorsi96 and LucasJSch
+ * @since 1-04-2021
+ */
+public class PointcloudMessageConverter
+        implements DataToRosMessageConverter<PointCloud2, Frame> {
+    private static final String TAG = PointcloudMessageConverter.class.getSimpleName();
+    private ChannelBuffer cb;
+    private FloatBuffer fb;
+
+    @Override
+    public PointCloud2 toRosMessage(Frame frame, PointCloud2 baseMessage) {
+        if (cb != null && fb != null) {
+            cb.clear();
+            fb.clear();
+        }
+        try (PointCloud pointCloud = frame.acquirePointCloud()){
+            FloatBuffer fb = pointCloud.getPoints();
+            float[] farray = new float[fb.remaining()];
+            fb.get(farray);
+            byte[] ba = floatArrayToByteArray(farray);
+            ChannelBuffer cb = baseMessage.getData();
+            cb.writeBytes(ba);
+            baseMessage.setData(cb);
+        } catch (Exception e) {
+            Log.w(TAG, e.getMessage());
+        }
+        return baseMessage;
+    }
+
+    public static byte[] floatArrayToByteArray(float[] values){
+        ByteBuffer buffer = ByteBuffer.allocate(4 * values.length);
+        for (float value : values){
+            buffer.putFloat(value);
+        }
+        return buffer.array();
+    }
+
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CameraInfoPublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CameraInfoPublisher.java
@@ -1,0 +1,40 @@
+package com.jamie.android_ros.arcore_ros.ros.publishers;
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.jamie.android_ros.arcore_ros.common.Utilities;
+import com.jamie.android_ros.arcore_ros.ros.converters.CameraInfoMessageConverter;
+
+import org.ros.node.ConnectedNode;
+import org.ros.node.topic.Publisher;
+
+import sensor_msgs.CameraInfo;
+
+public class CameraInfoPublisher implements MessagePublisher<Frame> {
+    private static final String TAG = CameraInfoPublisher.class.getSimpleName();
+    private final Publisher<CameraInfo> publisher;
+    private final CameraInfoMessageConverter converter;
+    private CameraInfo msg;
+
+    public CameraInfoPublisher(ConnectedNode connectedNode,
+                               CameraInfoMessageConverter converter,
+                                    String topic) {
+        this.converter = converter;
+        this.publisher = connectedNode.newPublisher(topic, sensor_msgs.CameraInfo._TYPE);
+        this.msg = publisher.newMessage();
+    }
+
+    @Override
+    public void publish(Frame frame) {
+        Log.v(TAG, "Publishing");
+        msg = converter.toRosMessage(frame, msg);
+        Utilities.setHeader(msg.getHeader());
+        publisher.publish(msg);
+    }
+
+    @Override
+    public void onDataReceived(Frame frame) {
+        publish(frame);
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CameraInfoPublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CameraInfoPublisher.java
@@ -11,6 +11,12 @@ import org.ros.node.topic.Publisher;
 
 import sensor_msgs.CameraInfo;
 
+/**
+ * Publishes {@code CameraInfo} messages based on given {@code Frame} updates.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class CameraInfoPublisher implements MessagePublisher<Frame> {
     private static final String TAG = CameraInfoPublisher.class.getSimpleName();
     private final Publisher<CameraInfo> publisher;

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CompressedImagePublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CompressedImagePublisher.java
@@ -12,6 +12,12 @@ import org.ros.node.topic.Publisher;
 
 import sensor_msgs.CompressedImage;
 
+/**
+ * Publishes {@code CompressedImage} messages based on given {@code Frame} updates.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class CompressedImagePublisher  implements MessagePublisher<Frame> {
     private static final String TAG = CompressedImagePublisher.class.getSimpleName();
     private final Publisher<CompressedImage> publisher;

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CompressedImagePublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/CompressedImagePublisher.java
@@ -1,0 +1,41 @@
+package com.jamie.android_ros.arcore_ros.ros.publishers;
+
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.jamie.android_ros.arcore_ros.common.Utilities;
+import com.jamie.android_ros.arcore_ros.ros.converters.CompressedImageMessageConverter;
+
+import org.ros.node.ConnectedNode;
+import org.ros.node.topic.Publisher;
+
+import sensor_msgs.CompressedImage;
+
+public class CompressedImagePublisher  implements MessagePublisher<Frame> {
+    private static final String TAG = CompressedImagePublisher.class.getSimpleName();
+    private final Publisher<CompressedImage> publisher;
+    private final CompressedImageMessageConverter converter;
+    private CompressedImage msg;
+
+    public CompressedImagePublisher(ConnectedNode connectedNode,
+                                    CompressedImageMessageConverter converter,
+                                    String topic) {
+        this.converter = converter;
+        this.publisher = connectedNode.newPublisher(topic, sensor_msgs.CompressedImage._TYPE);
+        this.msg = publisher.newMessage();
+    }
+
+    @Override
+    public void publish(Frame frame) {
+        Log.v(TAG, "Publishing");
+        msg = converter.toRosMessage(frame, msg);
+        Utilities.setHeader(msg.getHeader());
+        publisher.publish(msg);
+    }
+
+    @Override
+    public void onDataReceived(Frame frame) {
+        publish(frame);
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/DepthImagePublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/DepthImagePublisher.java
@@ -1,0 +1,41 @@
+package com.jamie.android_ros.arcore_ros.ros.publishers;
+
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.jamie.android_ros.arcore_ros.common.Utilities;
+import com.jamie.android_ros.arcore_ros.ros.converters.DepthImageMessageConverter;
+
+import org.ros.node.ConnectedNode;
+import org.ros.node.topic.Publisher;
+
+import sensor_msgs.Image;
+
+public class DepthImagePublisher  implements MessagePublisher<Frame> {
+    private static final String TAG = CompressedImagePublisher.class.getSimpleName();
+    private final Publisher<Image> publisher;
+    private final DepthImageMessageConverter converter;
+    private Image msg;
+
+    public DepthImagePublisher(ConnectedNode connectedNode,
+                                    DepthImageMessageConverter converter,
+                                    String topic) {
+        this.converter = converter;
+        this.publisher = connectedNode.newPublisher(topic, sensor_msgs.Image._TYPE);
+        this.msg = publisher.newMessage();
+    }
+
+    @Override
+    public void publish(Frame frame) {
+        Log.v(TAG, "Publishing");
+        msg = converter.toRosMessage(frame, msg);
+        Utilities.setHeader(msg.getHeader());
+        publisher.publish(msg);
+    }
+
+    @Override
+    public void onDataReceived(Frame frame) {
+        publish(frame);
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/DepthImagePublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/DepthImagePublisher.java
@@ -12,6 +12,12 @@ import org.ros.node.topic.Publisher;
 
 import sensor_msgs.Image;
 
+/**
+ * Publishes {@code Image} messages based on given {@code Frame} updates.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class DepthImagePublisher  implements MessagePublisher<Frame> {
     private static final String TAG = CompressedImagePublisher.class.getSimpleName();
     private final Publisher<Image> publisher;

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/ImuPublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/ImuPublisher.java
@@ -25,6 +25,7 @@ public class ImuPublisher implements MessagePublisher<ImuData> {
         this.publisher = connectedNode.newPublisher(topic, sensor_msgs.Imu._TYPE);
         this.msg = publisher.newMessage();
     }
+
     public void publish(ImuData data) {
         Log.v(TAG, "Publishing");
         msg = converter.toRosMessage(data, msg);

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/PointcloudPublisher.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/publishers/PointcloudPublisher.java
@@ -1,0 +1,46 @@
+package com.jamie.android_ros.arcore_ros.ros.publishers;
+
+import android.util.Log;
+
+import com.google.ar.core.Frame;
+import com.jamie.android_ros.arcore_ros.common.Utilities;
+import com.jamie.android_ros.arcore_ros.ros.converters.PointcloudMessageConverter;
+
+import org.ros.node.ConnectedNode;
+import org.ros.node.topic.Publisher;
+
+import sensor_msgs.PointCloud2;
+
+/**
+ * Publishes {@code Pointcloud2} messages based on given {@code Frame} updates.
+ *
+ * @authors elector102, lorsi96 and LucasJSch
+ * @since 1-04-2021
+ */
+public class PointcloudPublisher implements MessagePublisher<Frame> {
+    private static final String TAG = CompressedImagePublisher.class.getSimpleName();
+    private final Publisher<PointCloud2> publisher;
+    private final PointcloudMessageConverter converter;
+    private PointCloud2 msg;
+
+    public PointcloudPublisher(ConnectedNode connectedNode,
+                               PointcloudMessageConverter converter,
+                               String topic) {
+        this.converter = converter;
+        this.publisher = connectedNode.newPublisher(topic, sensor_msgs.PointCloud2._TYPE);
+        this.msg = publisher.newMessage();
+    }
+
+    @Override
+    public void publish(Frame frame) {
+        Log.v(TAG, "Publishing");
+        msg = converter.toRosMessage(frame, msg);
+        Utilities.setHeader(msg.getHeader());
+        publisher.publish(msg);
+    }
+
+    @Override
+    public void onDataReceived(Frame frame) {
+        publish(frame);
+    }
+}

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CameraSensor.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CameraSensor.java
@@ -5,11 +5,11 @@ import com.google.ar.core.Frame;
 import com.google.ar.core.TrackingState;
 import com.jamie.android_ros.arcore_ros.common.LiveData;
 
-public class CompressedImageCameraSensor extends BaseSensor<Frame>  implements LiveData.Observer<Frame> {
+public class CameraSensor extends BaseSensor<Frame>  implements LiveData.Observer<Frame> {
 
     private final LiveData<Frame> liveFrame;
 
-    public CompressedImageCameraSensor(LiveData<Frame> liveFrame) {
+    public CameraSensor(LiveData<Frame> liveFrame) {
         this.liveFrame = liveFrame;
     }
 

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CameraSensor.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CameraSensor.java
@@ -5,6 +5,14 @@ import com.google.ar.core.Frame;
 import com.google.ar.core.TrackingState;
 import com.jamie.android_ros.arcore_ros.common.LiveData;
 
+/** Sensor that retrieves {@code Frame} updates.
+ *
+ * As suggested for ARCore dependent sensors, it observes a {@code Frame} object via this codebase's
+ * {@code LiveData} class.
+ *
+ * @author Lucas Scheinkerman (LucasJSch)
+ * @since 1-04-2021
+ */
 public class CameraSensor extends BaseSensor<Frame>  implements LiveData.Observer<Frame> {
 
     private final LiveData<Frame> liveFrame;

--- a/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CompressedImageCameraSensor.java
+++ b/app/src/main/java/com/jamie/android_ros/arcore_ros/ros/sensors/CompressedImageCameraSensor.java
@@ -1,0 +1,33 @@
+package com.jamie.android_ros.arcore_ros.ros.sensors;
+
+import com.google.ar.core.Camera;
+import com.google.ar.core.Frame;
+import com.google.ar.core.TrackingState;
+import com.jamie.android_ros.arcore_ros.common.LiveData;
+
+public class CompressedImageCameraSensor extends BaseSensor<Frame>  implements LiveData.Observer<Frame> {
+
+    private final LiveData<Frame> liveFrame;
+
+    public CompressedImageCameraSensor(LiveData<Frame> liveFrame) {
+        this.liveFrame = liveFrame;
+    }
+
+    @Override
+    public void start() {
+        liveFrame.observe(this);
+    }
+
+    @Override
+    public void stop() {
+        liveFrame.removeObserver(this);
+    }
+
+    @Override
+    public void onChanged(Frame frame) {
+        Camera camera = liveFrame.getValue().getCamera();
+        if(camera.getTrackingState() == TrackingState.TRACKING){
+            notifyListeners(frame);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the following publishers with the corresponding ros message format:
 - Depth image (sensor_msgs/Image)
 - Normal camera image (sensor_msgs/CompressedImage)
 - Pointcloud (sensor_msgs.Pointcloud2)
 - Camera information (sensor_msgs/CameraInfo)

Each of this publishers implies implementing a `MessageConverter` class and a `Publisher` class.
Also, a single `CameraSensor` class was implemented to handle the callbacks when a frame is updated. This class was used for every new publisher in this PR.

Also, to allow depth images, the supported ARCore version was upgraded from 1.5 to 1.18.